### PR TITLE
Add tests and integrate with CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,24 @@ name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
 on: push
 
 jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: "Set up Python"
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
+      - name: Install dependencies
+        run: uv pip install . pytest
+      - name: Run tests
+        run: pytest -vv
   build:
+    needs: tests
     name: Build distribution 📦
     runs-on: ubuntu-latest
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,4 +13,4 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [dependency-groups]
-dev = ["pyright>=1.1.400", "ruff>=0.11.8", "uvicorn[standard]>=0.34.2"]
+dev = ["pyright>=1.1.400", "ruff>=0.11.8", "uvicorn[standard]>=0.34.2", "pytest>=8.2.1"]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,37 @@
+import socket
+import threading
+import time
+
+import pytest
+import uvicorn
+
+from rpyc_ws import connect_ws, create_rpyc_fastapi_app
+
+
+def _run_server(app, host, port):
+    config = uvicorn.Config(app, host=host, port=port, log_level="warning")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    while not server.started:
+        time.sleep(0.01)
+    return server, thread
+
+
+def test_client_server_roundtrip():
+    app = create_rpyc_fastapi_app()
+    host = "127.0.0.1"
+    sock = socket.socket()
+    sock.bind((host, 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    server, thread = _run_server(app, host, port)
+    try:
+        conn = connect_ws(f"ws://{host}:{port}/rpyc-ws/")
+        try:
+            assert conn.modules.builtins.sum([1, 2, 3]) == 6
+        finally:
+            conn.close()
+    finally:
+        server.should_exit = True
+        thread.join()

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,0 +1,36 @@
+import pytest
+from rpyc_ws.stream import CallbackStream
+
+def test_read_and_close():
+    frames = [b"hello", b"world", b"", b"!"]
+    def recv(timeout):
+        return frames.pop(0)
+    sent = []
+    closed = []
+    def send(data):
+        sent.append(data)
+    def close():
+        closed.append(True)
+    stream = CallbackStream(recv, send, close)
+    assert stream.read(5) == b"hello"
+    assert stream.read(5) == b"world"
+    with pytest.raises(EOFError):
+        stream.read(1)
+    assert closed == [True]
+
+
+def test_write_after_close_raises():
+    def recv(timeout):
+        return b""
+    events = []
+    def send(data):
+        events.append(data)
+    def close():
+        events.append("closed")
+    stream = CallbackStream(recv, send, close)
+    with pytest.raises(EOFError):
+        stream.read(1)
+    assert stream.closed
+    with pytest.raises(EOFError):
+        stream.write(b"data")
+    assert "closed" in events


### PR DESCRIPTION
## Summary
- add integration and unit tests for CallbackStream
- include pytest in dev dependencies
- run tests in CI before building artifacts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68435bed6640832a875924c81a8ed2f7